### PR TITLE
ci: Promote Copilot user-story files to Issues (native Copilot)

### DIFF
--- a/.github/workflows/promote-copilot-story.yml
+++ b/.github/workflows/promote-copilot-story.yml
@@ -6,7 +6,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   promote:


### PR DESCRIPTION
This workflow promotes Copilot-generated story files into GitHub Issues automatically.

How it works
- Triggers on PR open/update.
- Detects files added under `docs/user-stories/*.md`.
- Creates a new Issue for each story (labels: `user-story`, `generated`).
- Comments on the PR with links to the created issues.

Why
- Native Copilot writes BA output as files in PRs. This keeps native Copilot while making issues the source of truth for planning.

Notes
- No external LLMs or secrets.
- We can later parse frontmatter to map MoSCoW/points into labels or fields if desired.
